### PR TITLE
t-yosemite-r7-201 modifications

### DIFF
--- a/client.py
+++ b/client.py
@@ -23,7 +23,7 @@ windows_other_issues = ["T-W1064-MS-072", "T-W1064-MS-130", "T-W1064-MS-177", "T
 windows_all_problems = windows_pxe + windows_hdd + windows_other_issues  # DON'T EDIT THIS! 
 
 # OSX 
-osx_ssh_stdio = ["t-yosemite-r7-201", "t-yosemite-r7-322", "t-yosemite-r7-356"]
+osx_ssh_stdio = ["t-yosemite-r7-322", "t-yosemite-r7-356"]
 osx_ssh_unresponsive = ["t-yosemite-r7-078", "t-yosemite-r7-124", "t-yosemite-r7-130", "t-yosemite-r7-263", "t-yosemite-r7-267",
                         "t-yosemite-r7-357"]
 osx_other_issues = ["t-yosemite-r7-442"]

--- a/client.py
+++ b/client.py
@@ -50,6 +50,7 @@ ignore_ms_windows = ["T-W1064-MS-010", "T-W1064-MS-011", "T-W1064-MS-012", "T-W1
 
 ignore_ms_osx = ["t-yosemite-r7-100",  # :dragrom // Staging Pool.
                  "t-yosemite-r7-101",  # :dragrom // Staging Pool.
+                 "t-yosemite-r7-201",  # :jwatkins // Host is moved and renamed as install2.test.releng.mdc..bug # 14771450
                  "t-yosemite-r7-380",  # :dragrom // Staging Pool.
                  "t-yosemite-r7-394"]  # :dragrom // Staging Pool.
 workersList = []


### PR DESCRIPTION
Removed t-yosemite-r7-201 from the list of broken machines with stdio problems and moved it to ignore_ms_osx since jwatkins renamed it in bug # 14771450