### PR TITLE
Removed a few fixed machine from windows and fixed missing bracket

### DIFF
--- a/client.py
+++ b/client.py
@@ -126,6 +126,7 @@ machines_to_ignore = {
                 "date": "23.07.2018",
                 "update": "https://bugzilla.mozilla.org/show_bug.cgi?id=1477656#c1"
             },
+        },
     },
     "osx": {
         "loaner": {

--- a/client.py
+++ b/client.py
@@ -126,21 +126,6 @@ machines_to_ignore = {
                 "date": "23.07.2018",
                 "update": "https://bugzilla.mozilla.org/show_bug.cgi?id=1477656#c1"
             },
-            "T-W1064-MS-316": {
-                "bug": "https://bugzilla.mozilla.org/show_bug.cgi?id=1480775",
-                "date": "06.08.2018",
-                "update": "New bug, no updates yet."
-            },
-            "T-W1064-MS-326": {
-                "bug": "https://bugzilla.mozilla.org/show_bug.cgi?id=1480779",
-                "date": "06.08.2018",
-                "update": "New bug, no updates yet."
-            },
-            "T-W1064-MS-340": {
-                "bug": "https://bugzilla.mozilla.org/show_bug.cgi?id=1481161",
-                "date": "06.08.2018",
-                "update": "New bug, no updates yet."
-            },
         },
     },
     "osx": {

--- a/client.py
+++ b/client.py
@@ -141,6 +141,21 @@ machines_to_ignore = {
             },
         },
         "ssh_stdio": {
+            "t-yosemite-r7-045": {
+                "bug": "https://bugzilla.mozilla.org/show_bug.cgi?id=1480658",
+                "date": "23.07.2018",
+                "update": "New bug, no updates yet."
+            },
+            "t-yosemite-r7-087": {
+                "bug": "https://bugzilla.mozilla.org/show_bug.cgi?id=1480659",
+                "date": "23.07.2018",
+                "update": "New bug, no updates yet."
+            },
+            "t-yosemite-r7-142": {
+                "bug": "https://bugzilla.mozilla.org/show_bug.cgi?id=1480655",
+                "date": "23.07.2018",
+                "update": "New bug, no updates yet."
+            },
             "t-yosemite-r7-201": {
                 "bug": "https://bugzilla.mozilla.org/show_bug.cgi?id=1477150",
                 "date": "23.07.2018",
@@ -156,6 +171,11 @@ machines_to_ignore = {
             "t-yosemite-r7-130": {
                 "bug": "https://bugzilla.mozilla.org/show_bug.cgi?id=1474270",
                 "date": "28.07.2018",
+                "update": "New bug, no updates yet."
+            },
+            "t-yosemite-r7-241": {
+                "bug": "https://bugzilla.mozilla.org/show_bug.cgi?id=1477788",
+                "date": "01.08.2018",
                 "update": "New bug, no updates yet."
             },
             "t-yosemite-r7-381": {


### PR DESCRIPTION
Removed T-W1064-MS-{316, 326, 340}, bugs resolved as fixed and the machines are working perfectly.
Also had to resolve a merge conflict that resulted in a missing bracket, fixed.